### PR TITLE
Replace PlayFabSettings.TitleId with PlayFabSettings.staticSettings.TitleId

### DIFF
--- a/playfab-docs/sdks/c-sharp/quickstart.md
+++ b/playfab-docs/sdks/c-sharp/quickstart.md
@@ -74,7 +74,7 @@ public static class Program
     private static bool _running = true;
     static void Main(string[] args)
     {
-        PlayFabSettings.TitleId = "144"; // Please change this value to your own titleId from PlayFab Game Manager
+        PlayFabSettings.staticSettings.TitleId = "144"; // Please change this value to your own titleId from PlayFab Game Manager
 
         var request = new LoginWithCustomIDRequest { CustomId = "GettingStartedGuide", CreateAccount = true };
         var loginTask = PlayFabClientAPI.LoginWithCustomIDAsync(request);
@@ -139,7 +139,7 @@ This optional last section describes each part of Program.cs in detail.
 
 ### Inside of Main
 
-- `PlayFabSettings.TitleId = "xxxx";`
+- `PlayFabSettings.staticSettings.TitleId = "xxxx";`
   - Every PlayFab developer creates a title in Game Manager. When you publish your game, you must code that titleId into your game. This lets the client know how to access the correct data within PlayFab. For now, just consider it a mandatory step that makes PlayFab work.
 
 - `var request = new LoginWithCustomIDRequest { CustomId = "GettingStartedGuide", CreateAccount = true };`
@@ -169,7 +169,7 @@ This optional last section describes each part of Program.cs in detail.
   - If apiError is not null, your API has failed.
   - API calls can fail for many reasons, and you should always attempt to handle failure.
   - Why API calls fail (In order of likelihood).
-    - PlayFabSettings.TitleId is not set. If you forget to set titleId to your title, then nothing will work.
+    - PlayFabSettings.staticSettings.TitleId is not set. If you forget to set titleId to your title, then nothing will work.
     - Request parameters. If you have not provided the correct or required information for a particular API call, then it will fail. See error.errorMessage, error.errorDetails, or error.GenerateErrorReport() for more info.
     - Device connectivity issue. Cell-phones lose/regain connectivity constantly, and so any API call at any time can fail randomly, and then work immediately after. Going into a tunnel can disconnect you completely.
     - PlayFab server issue. As with all software, there can be issues. See our [release notes](../../release-notes/index.md) for updates.


### PR DESCRIPTION
`PlayFabSettings.TitleId` is obsolete.(A warning is displayed)

Replace `PlayFabSettings.TitleId` with `PlayFabSettings.staticSettings.TitleId`.