### PR TITLE
Add release notes for v1.2.0 and v1.2.2

### DIFF
--- a/playfab-docs/features/multiplayer/networking/release-notes.md
+++ b/playfab-docs/features/multiplayer/networking/release-notes.md
@@ -14,7 +14,7 @@ ms.localizationpriority: medium
 
 PlayFab Party is available on [Nuget.org](https://www.nuget.org/profiles/PlayFab)!
 
-PlayFab Party is available on [GitHub.com](https://github.com/PlayFab/PlayFabParty/releases)
+PlayFab Party for Android and iOS are available on [GitHub.com](https://github.com/PlayFab/PlayFabParty/releases)
 
 Release notes for the Xbox Live Helper library can be found [here](party-xboxlive-relnotes.md).
 

--- a/playfab-docs/features/multiplayer/networking/release-notes.md
+++ b/playfab-docs/features/multiplayer/networking/release-notes.md
@@ -14,7 +14,22 @@ ms.localizationpriority: medium
 
 PlayFab Party is available on [Nuget.org](https://www.nuget.org/profiles/PlayFab)!
 
+PlayFab Party is available on [GitHub.com](https://github.com/PlayFab/PlayFabParty/releases)
+
 Release notes for the Xbox Live Helper library can be found [here](party-xboxlive-relnotes.md).
+
+## 1.2.2
+
+### iOS Changes
+
+- Adds support for the volume control API.
+
+## 1.2.0
+
+### Android Changes
+
+- Adds support for the volume control API.
+- Removes audio focus handling from the library.  Host applications are now expected to implement their own focus handling logic.
 
 ## 1.0.1
 


### PR DESCRIPTION
This adds release notes for v1.2.* and a link to the iOS and Android release pages.