### PR TITLE
Fix typo in toc.yml

### DIFF
--- a/playfab-docs/toc.yml
+++ b/playfab-docs/toc.yml
@@ -2,7 +2,7 @@
   href: index.yml
 - name: What is PlayFab?
   href: what-is-playfab.md  
-- name: Game Manger
+- name: Game Manager
   href: gamemanager/toc.yml
 - name: Build
   expanded: true


### PR DESCRIPTION
Noticed a typo in the ToC when going through the documentation.