### PR TITLE
Fix Bullet Point Formatting

### DIFF
--- a/playfab-docs/features/pricing/Meters/profile-writes.md
+++ b/playfab-docs/features/pricing/Meters/profile-writes.md
@@ -31,13 +31,13 @@ The following APIs cause the Profile writes meter to increment.
 - [BanUsers](https://docs.microsoft.com/rest/api/playfab/admin/account-management/banusers?view=playfab-rest)
     Bans users by PlayFab ID with optional IP address, or MAC address for the provided game.
 
--[CreateActionsOnPlayersInSegmentTask](https://docs.microsoft.com/rest/api/playfab/admin/scheduledtask/createactionsonplayersinsegmenttask?view=playfab-rest)
+- [CreateActionsOnPlayersInSegmentTask](https://docs.microsoft.com/rest/api/playfab/admin/scheduledtask/createactionsonplayersinsegmenttask?view=playfab-rest)
     Create an ActionsOnPlayersInSegment task, which iterates through all players in a segment to execute action.
 
--[CreatePlayerSharedSecret](https://docs.microsoft.com/rest/api/playfab/admin/authentication/createplayersharedsecret?view=playfab-rest)
+- [CreatePlayerSharedSecret](https://docs.microsoft.com/rest/api/playfab/admin/authentication/createplayersharedsecret?view=playfab-rest)
     Creates a new Player Shared Secret Key. It may take up to 5 minutes for this key to become generally available after this API returns.
 
--[CreatePlayerStatisticDefinition](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/createplayerstatisticdefinition?view=playfab-rest)
+- [CreatePlayerStatisticDefinition](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/createplayerstatisticdefinition?view=playfab-rest)
     Adds a new player statistic configuration to the title, optionally allowing the developer to specify a reset interval and an aggregation method.
 
 - [DeleteMasterPlayerAccount](https://docs.microsoft.com/rest/api/playfab/admin/account-management/deletemasterplayeraccount?view=playfab-rest)
@@ -58,10 +58,10 @@ The following APIs cause the Profile writes meter to increment.
 - [GrantItemsToUsers](https://docs.microsoft.com/rest/api/playfab/admin/player-item-management/grantitemstousers?view=playfab-rest)
     Adds the specified items to the specified user inventories
 
--[IncrementLimitedEditionItemAvailability](https://docs.microsoft.com/rest/api/playfab/admin/player-item-management/incrementlimitededitionitemavailability?view=playfab-rest)
+- [IncrementLimitedEditionItemAvailability](https://docs.microsoft.com/rest/api/playfab/admin/player-item-management/incrementlimitededitionitemavailability?view=playfab-rest)
     Increases the global count for the given scarce resource.
 
--[IncrementPlayerStatisticVersion](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/incrementplayerstatisticversion?view=playfab-rest)
+- [IncrementPlayerStatisticVersion](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/incrementplayerstatisticversion?view=playfab-rest)
     Resets the indicated statistic, removing all player entries for it and backing up the old values.
 
 - [RefundPurchase](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/refundpurchase?view=playfab-rest)
@@ -79,7 +79,7 @@ The following APIs cause the Profile writes meter to increment.
 - [ResetUserStatistics](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/resetuserstatistics?view=playfab-rest)
     Completely removes all statistics for the specified user, for the current game.
 
--[ResolvePurchaseDispute](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/resolvepurchasedispute?view=playfab-rest)
+- [ResolvePurchaseDispute](https://docs.microsoft.com/rest/api/playfab/admin/player-data-management/resolvepurchasedispute?view=playfab-rest)
     Attempts to resolve a dispute with the original order's payment provider.
     
 - [RevokeAllBansForUser](https://docs.microsoft.com/rest/api/playfab/admin/account-management/revokeallbansforuser?view=playfab-rest)


### PR DESCRIPTION
Some items don't render as bullet points in the list due to missing spaces after the `-`

![image](https://user-images.githubusercontent.com/465040/137541413-8561d930-47ba-466f-b5a5-0bc880adec22.png)
