### PR TITLE
Clarified SDK access for lobby after it went into public preview

### DIFF
--- a/playfab-docs/features/multiplayer/lobby/lobby-matchmaking-sdks/lobby-matchmaking-sdks.md
+++ b/playfab-docs/features/multiplayer/lobby/lobby-matchmaking-sdks/lobby-matchmaking-sdks.md
@@ -19,7 +19,7 @@ This topic describes all the Azure PlayFab Lobby and Matchmaking SDKs that are c
 
 If you don't find what you need, let us know by writing a post on our [forums](https://community.playfab.com/index.html).
 
-Access to SDKs for PC(Win32), Nintendo Switch, PlayStation 4, PlayStation 5, PC (GDK), and Xbox (GDK) requires special approval and adherence to platform policies.
+Access to SDKs for Nintendo Switch, PlayStation 4, PlayStation 5, and Xbox (GDK) requires special approval and adherence to platform policies.
 
 If you're looking for the core PlayFab SDK that helps you implement most of our features, including LiveOps, economy, matchmaking, and data analytics, see [PlayFab SDKs](../../../../sdks/playfab-sdk-intro.md).
 


### PR DESCRIPTION
After checking the docs and links it appears taht PC(Win32), PC (GDK) do not need additional approval / access to access the binaries through the public GitHub repositories.

So, we should make sure documentation is consistent with SDK access.