### PR TITLE
remove google cloud messaging references

### DIFF
--- a/playfab-docs/features/engagement/push-notifications/push-notifications-for-android.md
+++ b/playfab-docs/features/engagement/push-notifications/push-notifications-for-android.md
@@ -21,48 +21,33 @@ ms.localizationpriority: medium
 
 ## Configuring the Android notification channel
 
-> [!NOTE]
-> The Google and Firebase developer consoles experience changes regularly. The setup description in this section best describes the values you need - and how to get them - as of June 2017.
-
-### Google and Firebase setup
+### Firebase setup
 
 There are three Google websites that you must use and synchronize. In Google/Firebase, there are both Projects and Apps:
 
 - **Project**:
-  - Ensure that your project is set up and accessible from the [Google API Manager](https://console.developers.google.com/).
   - Import your project into the [Firebase Console](https://console.firebase.google.com/) if it's not already there.
 
 - **App**:
   - [Firebase](https://console.firebase.google.com/) Projects contain apps.
-  - The [Google Play Dev Console](https://play.google.com/apps/publish/) also contains apps.
   - Make sure your app exists in both locations, with the same name and identifier (for example, [Unicorn Battle and com.playfab.unicornbattle2](https://play.google.com/store/apps/details?id=com.playfab.unicornbattle2)).
 
-### PlayFab requires a server API key
+### PlayFab requires a server private key file
 
-- You can get this key from the [Google API Manager](https://console.developers.google.com/), or from the [Firebase Console](https://console.firebase.google.com/)
-- **Google API Manager**:
-  - Select your **Project**.
-  - Select **Credentials** (left menu).
-  - The **Firebase Project** import will have created a **ServerKey** for you here.
+- You can get this private key file from the [Firebase Console](https://console.firebase.google.com/)
 - **Firebase Console**:
   - Select your **Project** or **App**, and find the **Settings** option (there are many ways to do this, all of which lead you to the same place).
-  - In the **General** tab, this is listed as the **Web API Key**.
-  - In the **Cloud Messaging** tab, this is listed as the **Legacy server key**.
+  - In the **Service accounts** tab, click the **Generate new private key** button to download the JSON file.
 
-- All of the keys described above should be identical, and they are all the API key described in this document.
+## Using the private key file
 
-> [!NOTE]
-> If they are not identical, the **Legacy server key** is the one needed by PlayFab.
-
-## Using the API key
-
-- Provide your API key in one of two ways:
-  1. Input your key directly into the **Game Manager UI**: **Settings** (for your **Title**) > **Push Notifications** > **Android**.
+- Provide your private key file in one of two ways:
+  1. Upload the private key file directly into the **Game Manager UI**: **Settings** (for your **Title**) > **Push Notifications** > **Android**.
   2. Or call [SetupPushNotification](xref:titleid.playfabapi.com.admin.title-widedatamanagement.setuppushnotification) using Postman or a Unity project with Server API methods enabled.
   
   - Name: **your_game_name**
   - Platform: **GCM**
-  - Credential: (**Google server API Key**): `AIza**ppo`
+  - Credential: (**private key file contents as a string**): `{ ... }`
   - Overwrite OldARN: `true`
   - You should receive an **HTTP 200 OK** response with data similar to the following.
 


### PR DESCRIPTION
FCM has replaced GCM for push notifications. The documentation has changed to reflect the new setup steps for Android push notifications using the new infrastructure and credentials.