### PR TITLE
Madelaga/leaderboards private preview

### DIFF
--- a/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
@@ -1,7 +1,7 @@
 ---
-title: Entity Stats & Leaderboards
+title: Entity Stats and Leaderboards
 author: joannaleecy
-description: Landing page for Entity Stats & Leaderboards
+description: Landing page for Entity Stats and Leaderboards
 ms.author: madelaga
 ms.date: 03/29/2024
 ms.topic: article
@@ -10,7 +10,7 @@ keywords: playfab, social, tournaments, leaderboards
 ms.localizationpriority: medium
 ---
 
-# Entity Stats & Leaderboards (Private Preview)
+# Entity Stats and Leaderboards (Private Preview)
 
 We are excited to announce two new services for game creators: Entity Stats and Leaderboards. These services will help you create engaging and competitive gaming experiences for your players, with more features, flexibility, and customization than ever before. The core capabilities of each product as you know them remain intact.
 
@@ -18,11 +18,11 @@ Entity Stats will enable you to collect and analyze various game metrics, such a
 
 Entity Leaderboards provide a means by which to rank and order profiles. These rankings can be based on a corresponding statistic, or they can be driven entirely by updates directly to a leaderboard. That's all to say that these two new services can not only be used in tandem but also support full independent adoption - you can create and manage leaderboards without collecting any stats, and you can collect and analyze stats without building any leaderboards.
 
-Along with this fundamental change to how these services are supported in PlayFab comes both returning & new features, including the following:
+Along with this fundamental change to how these services are supported in PlayFab comes both returning and new features, including the following:
 
 - Full integration with the [Entity Programming Model](/gaming/playfab/features/data/entities).
-- Resettable stats & leaderboards, and version retention. 
-- Metadata support for stats & leaderboards.
+- Resettable stats and leaderboards, with version retention. 
+- Metadata support for stats and leaderboards.
 - Multicolumn leaderboards for enhanced tie-breaking.
 - LiveOps Automation integration (PlayStream Events).
 - On-demand friend-based leaderboards.

--- a/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
@@ -28,7 +28,7 @@ Along with this fundamental change to how these services are supported in PlayFa
 - On-demand friend-based leaderboards.
 - Full CRUD support, via API (UX pending).
 
-_Please note that feature availability may depend on the stage of release, with some only become available during Public Preview._
+_Please note that feature availability may depend on the stage of release, with some only becoming available during Public Preview._
 
 Both services are powered by our PlayFab cloud services platform, which ensures high availability, scalability, and security. Access will be made optimal via our easy-to-use APIs and SDKs.
 

--- a/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
@@ -32,6 +32,6 @@ _Please note that feature availability may depend on the stage of release, with 
 
 Both services are powered by our PlayFab cloud services platform, which ensures high availability, scalability, and security. Access will be made optimal via our easy-to-use APIs and SDKs.
 
-Any studio with interest in our new services and a willingness to provide feedback are encouraged to request access for our Private Preview. To do so, please complete the following survey so that we may better understand your feature needs: LINK.
+Any studio with interest in our new services and a willingness to provide feedback are encouraged to request access for our Private Preview. To do so, please complete the following survey so that we may better understand your feature needs: [Private Preview Program Application](https://forms.office.com/r/RdiQuf9768).
 
 We're thrilled to be building these services and can't wait to see the experiences it enables. Thank you for joining us on this journey, and we look forward to what's to come.

--- a/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md
@@ -1,0 +1,37 @@
+---
+title: Entity Stats & Leaderboards
+author: joannaleecy
+description: Landing page for Entity Stats & Leaderboards
+ms.author: madelaga
+ms.date: 03/29/2024
+ms.topic: article
+ms.service: playfab
+keywords: playfab, social, tournaments, leaderboards
+ms.localizationpriority: medium
+---
+
+# Entity Stats & Leaderboards (Private Preview)
+
+We are excited to announce two new services for game creators: Entity Stats and Leaderboards. These services will help you create engaging and competitive gaming experiences for your players, with more features, flexibility, and customization than ever before. The core capabilities of each product as you know them remain intact.
+
+Entity Stats will enable you to collect and analyze various game metrics, such as player performance, progress, behavior, and preferences. You can use these insights to improve your game design, balance, and monetization. You can also display your stats in your game or on your website, sharing them with your players and community.
+
+Entity Leaderboards provide a means by which to rank and order profiles. These rankings can be based on a corresponding statistic, or they can be driven entirely by updates directly to a leaderboard. That's all to say that these two new services can not only be used in tandem but also support full independent adoption - you can create and manage leaderboards without collecting any stats, and you can collect and analyze stats without building any leaderboards.
+
+Along with this fundamental change to how these services are supported in PlayFab comes both returning & new features, including the following:
+
+- Full integration with the [Entity Programming Model](/gaming/playfab/features/data/entities).
+- Resettable stats & leaderboards, and version retention. 
+- Metadata support for stats & leaderboards.
+- Multicolumn leaderboards for enhanced tie-breaking.
+- LiveOps Automation integration (PlayStream Events).
+- On-demand friend-based leaderboards.
+- Full CRUD support, via API (UX pending).
+
+_Please note that feature availability may depend on the stage of release, with some only become available during Public Preview._
+
+Both services are powered by our PlayFab cloud services platform, which ensures high availability, scalability, and security. Access will be made optimal via our easy-to-use APIs and SDKs.
+
+Any studio with interest in our new services and a willingness to provide feedback are encouraged to request access for our Private Preview. To do so, please complete the following survey so that we may better understand your feature needs: LINK.
+
+We're thrilled to be building these services and can't wait to see the experiences it enables. Thank you for joining us on this journey, and we look forward to what's to come.

--- a/playfab-docs/features/social/tournaments-leaderboards/index.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/index.md
@@ -21,7 +21,7 @@ Using event or tournament leaderboards are great ways of increasing engagement w
 
 Leaderboards are essentially rankings of entities such as players, groups, or items. A leaderboard ranks a list of entities based on their respective values. For example, “High Scores” is one of the most common implementations of leaderboards.
 
-## Why Use Leaderboards?
+## Why use Leaderboards?
 
 Leaderboards encourage competition among players of your game, and create incentives for the players to get better at the game. Adopting leaderboards allows players to keep up with each other and facilitates building a community. It can also result in players spending more time with the game and higher retention.
 

--- a/playfab-docs/features/social/tournaments-leaderboards/index.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/index.md
@@ -15,12 +15,7 @@ ms.localizationpriority: medium
 Using event or tournament leaderboards are great ways of increasing engagement within your game. Using PlayFab, you can easily set up a recurring tournament that awards prizes to the winners, reaches out to the participants, and gets your players coming back into your game to try and get the highest score.
 
 > [!IMPORTANT]
-> There is no opportunity for adoption of "Leaderboards v2" at this moment. Stay tuned for upcoming announcements: [PlayFab Roadmap](/gaming/playfab/roadmap).
-
-## The future of Stats and Leaderboards
-Statistics and their leaderboards have been critical components of many games across every genre throughout the history of the industry. Their integration into a title drives player engagement by acting as a reflection of their experience both in isolation and as it relates to a broader community. We at PlayFab have seen how you've utilized these services in unique and exciting ways. We want to better enable these experiences by providing a new set of Stats & Leaderboard APIs built with the [Entity Programming Model](/gaming/playfab/features/data/entities) in mind. 
-
-While we're eager to share details, we aim to do so in a process that delights. We're thrilled to be building this system and can't wait to see the experiences it enables. Thank you for joining us on this journey, and we look forward to [what's to come](/gaming/playfab/roadmap).
+> Teams are invited to request access to our Private Preview of "Leaderboards v2". Find the latest in our roadmap: [PlayFab Roadmap](/gaming/playfab/roadmap).
 
 ## What are Leaderboards? 
 

--- a/playfab-docs/features/social/tournaments-leaderboards/index.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/index.md
@@ -15,7 +15,7 @@ ms.localizationpriority: medium
 Using event or tournament leaderboards are great ways of increasing engagement within your game. Using PlayFab, you can easily set up a recurring tournament that awards prizes to the winners, reaches out to the participants, and gets your players coming back into your game to try and get the highest score.
 
 > [!IMPORTANT]
-> Teams are invited to request access to our Private Preview of "Leaderboards v2". Find the latest, included how to join, here: [Entity Stats & Leaderboards (Private Preview)](/gaming/playfab/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md).
+> Teams are invited to request access to our Private Preview of "Leaderboards v2". Find the latest, included how to join, here: [Entity Stats and Leaderboards (Private Preview)](/gaming/playfab/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md).
 
 ## What are Leaderboards? 
 

--- a/playfab-docs/features/social/tournaments-leaderboards/index.md
+++ b/playfab-docs/features/social/tournaments-leaderboards/index.md
@@ -15,7 +15,7 @@ ms.localizationpriority: medium
 Using event or tournament leaderboards are great ways of increasing engagement within your game. Using PlayFab, you can easily set up a recurring tournament that awards prizes to the winners, reaches out to the participants, and gets your players coming back into your game to try and get the highest score.
 
 > [!IMPORTANT]
-> Teams are invited to request access to our Private Preview of "Leaderboards v2". Find the latest in our roadmap: [PlayFab Roadmap](/gaming/playfab/roadmap).
+> Teams are invited to request access to our Private Preview of "Leaderboards v2". Find the latest, included how to join, here: [Entity Stats & Leaderboards (Private Preview)](/gaming/playfab/features/social/tournaments-leaderboards/entity-stats-and-leaderboards.md).
 
 ## What are Leaderboards? 
 


### PR DESCRIPTION
Adding a landing page for the new set of Stats & Leaderboard services. This update is meant to coincide with the upcoming PF Roadmap changes.