### PR TITLE
Chaning Naming From "AAD" to "Microsoft Accounts" 

### DIFF
--- a/playfab-docs/features/authentication/aad-authentication/index.md
+++ b/playfab-docs/features/authentication/aad-authentication/index.md
@@ -12,7 +12,7 @@ ms.localizationpriority: medium
 
 # Microsoft Authentication for Playfab Game Manager
 
-PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second is a Microsoft's authentication services Microsoft account and Microsoft Entra ID (formely know as Azure Active Directory).
+PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second is Microsoft's authentication services 'Microsoft Account' and 'Microsoft Entra ID (formely know as Azure Active Directory)'.
 
 ### To create a new Microsoft Authenicated user
 

--- a/playfab-docs/features/authentication/aad-authentication/index.md
+++ b/playfab-docs/features/authentication/aad-authentication/index.md
@@ -12,7 +12,7 @@ ms.localizationpriority: medium
 
 # Microsoft Authentication for Playfab Game Manager
 
-PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second is Microsoft's authentication services 'Microsoft Account' and 'Microsoft Entra ID (formerly known as Azure Active Directory)'.
+PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second uses Microsoft's authentication services&mdash;Microsoft Account and Microsoft Entra ID (formerly known as Azure Active Directory).
 
 ### To create a new Microsoft Authenicated user
 

--- a/playfab-docs/features/authentication/aad-authentication/index.md
+++ b/playfab-docs/features/authentication/aad-authentication/index.md
@@ -24,17 +24,17 @@ PlayFab now supports two methods of user authentication. The first is the origin
 
     ![Select Microsoft Authentication](media/AADDoc2.png)
 
-3. Assign roles as normal and send an invite. The user has the option to sign in via a Microsoft account.
+3. Assign roles as normal and send an invite. The user has the option to sign in via a Microsoft Account.
 
     ![Sign in with Microsoft](media/AADDoc3.png )
 
 ### Sign-up with a Microsoft Authenticated Account
 
-You can start a new PlayFab studio using a Microsoft account.
+You can start a new PlayFab studio using a Microsoft Account.
 
 1. Navigate to [developer.microsoft.com](https://developer.playfab.com/en-US/sign-up).
 2. Select **Sign up with Microsoft**.
 
 ### Microsoft Account Limitations
 
-Microsoft Account authentication is functional for individual users, including Microsoft account token exchange for programmatic authentication. It doesn't support groups or graph.
+Microsoft Account authentication is functional for individual users, including Microsoft Account token exchange for programmatic authentication. It doesn't support groups or graph.

--- a/playfab-docs/features/authentication/aad-authentication/index.md
+++ b/playfab-docs/features/authentication/aad-authentication/index.md
@@ -12,7 +12,7 @@ ms.localizationpriority: medium
 
 # Microsoft Authentication for Playfab Game Manager
 
-PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second is Microsoft's authentication services 'Microsoft Account' and 'Microsoft Entra ID (formely know as Azure Active Directory)'.
+PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second is Microsoft's authentication services 'Microsoft Account' and 'Microsoft Entra ID (formerly known as Azure Active Directory)'.
 
 ### To create a new Microsoft Authenicated user
 

--- a/playfab-docs/features/authentication/aad-authentication/index.md
+++ b/playfab-docs/features/authentication/aad-authentication/index.md
@@ -1,7 +1,7 @@
 ---
-title: Azure Active Directory for PlayFab
+title: Microsoft Accounts Authentication for PlayFab
 author: joannaleecy
-description: Provides an introduction to Azure Active Directory (AAD) authentication and steps for how to create a user with this auth method
+description: Provides an introduction to Microsoft Account authentication and steps for how to create a user with this auth method
 ms.author: joanlee
 ms.date: 11/11/2019
 ms.topic: article
@@ -10,11 +10,11 @@ keywords: playfab, analytics, metrics, webhooks, events
 ms.localizationpriority: medium
 ---
 
-# Azure Active Directory Authentication for Playfab Game Manager
+# Microsoft Authentication for Playfab Game Manager
 
-PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second is Azure Active Directory (Azure AD).
+PlayFab now supports two methods of user authentication. The first is the original PlayFab user authentication system. The second is a Microsoft's authentication services Microsoft account and Microsoft Entra ID (formely know as Azure Active Directory).
 
-### To create a new Azure AD user
+### To create a new Microsoft Authenicated user
 
 1. Navigate to your studio's users section.
 
@@ -28,13 +28,13 @@ PlayFab now supports two methods of user authentication. The first is the origin
 
     ![Sign in with Microsoft](media/AADDoc3.png )
 
-### Sign-up with Azure AD
+### Sign-up with a Microsoft Authenticated Account
 
-You can start a new PlayFab studio via Azure AD.
+You can start a new PlayFab studio using a Microsoft account.
 
 1. Navigate to [developer.microsoft.com](https://developer.playfab.com/en-US/sign-up).
-2. Select **Sign in with Microsoft**.
+2. Select **Sign up with Microsoft**.
 
-### Azure AD Limitations
+### Microsoft Account Limitations
 
-Azure AD authentication is functional for individual users, including Azure AD token exchange for programmatic authentication. It doesn't support groups or graph.
+Microsoft Account authentication is functional for individual users, including Microsoft account token exchange for programmatic authentication. It doesn't support groups or graph.


### PR DESCRIPTION
Updating to reflect that the name "Azure Active Directory" has be changed to Microsoft Entra ID. However, using "Microsoft Account" in doc as the implementation we doesn't leverage all of Entra ID and is closer to MSA.